### PR TITLE
ODROID-HC4: add red/power LED control, similar to the blue led

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
@@ -22,6 +22,18 @@
 		interrupts = <84 IRQ_TYPE_EDGE_FALLING>;
 		pulses-per-revolutions = <2>;
 	};
+
+
+        leds {
+                compatible = "gpio-leds";
+
+                led-red {
+                        color = <LED_COLOR_ID_RED>;
+                        function = LED_FUNCTION_POWER;
+                        gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "default-on";
+                };
+        };
 };
 
 &cpu_thermal {


### PR DESCRIPTION
ODROID-HC4: add red/power LED control, similar to the blue led
- in the HC4, the POWER (RED) LED can be controlled just like the blue led, it is connected to GPIOAO_7
- https://wiki.odroid.com/odroid-hc4/application_note/led_control#how_to_control_the_red_power_led_applicable_for_the_odroid-hc4_only 