### PR TITLE
ODROID-HC4 add red power led

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
@@ -22,6 +22,16 @@
 		interrupts = <84 IRQ_TYPE_EDGE_FALLING>;
 		pulses-per-revolutions = <2>;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		led-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
+		};
+	};
 };
 
 &cpu_thermal {


### PR DESCRIPTION
this is in addition to the blue led in the C4
defaults to always-on, but can be changed, example
echo rc-feedback > /sys/class/leds/red:power/trigger

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>